### PR TITLE
fix 86 hide time line stat chart

### DIFF
--- a/gui/src/sections/Menu/Menu.test.js
+++ b/gui/src/sections/Menu/Menu.test.js
@@ -32,7 +32,6 @@ test('Menu', async () => {
   expect(screen.getByText('Scatter Plot', ariaOther)).toBeTruthy()
   expect(screen.getByText('Prime Symptom', ariaOther)).toBeTruthy()
   expect(screen.getByText('Anti-bias Tool Kit', ariaOther)).toBeTruthy()
-  expect(screen.getByText('Time Line Stat. Chart', ariaCurrent)).toBeTruthy()
   expect(screen.getByText('Time Line', ariaOther)).toBeTruthy()
   expect(screen.getByText('Histogram', ariaOther)).toBeTruthy()
 })

--- a/gui/src/util/Constant/BaseConstantList.js
+++ b/gui/src/util/Constant/BaseConstantList.js
@@ -95,7 +95,6 @@ export const ROOT_MENU_SLUGS = [
   'Scatter',
   'PrimeSymptomList',
   'AntiBiasToolKit',
-  'TimeLineStatChart',
   'TimeLine',
   'HistogramMaker',
 ]

--- a/gui/src/util/Constant/BaseConstantList.js
+++ b/gui/src/util/Constant/BaseConstantList.js
@@ -1,12 +1,5 @@
 /***********************************/
 /*
- * Average lines on graphs
- */
-export const AVERAGE_LINE_DRAWN_WIDTH = 4
-
-
-/***********************************/
-/*
  * Correlation heatmap
  */
 export const CORRELATION_HEATMAP_FIELD_LIST = [


### PR DESCRIPTION
* there is an issue here with the deployment so this page is being temporarily hidden, however, a ticket exists to get this fixed, see issue https://github.com/toni-sharpe/brainstem-research/issues/59