### PR TITLE
feat 123 general improvements to Gantt ouput

### DIFF
--- a/gui/src/components/GanttBarWrapper/GanttBarWrapper.jsx
+++ b/gui/src/components/GanttBarWrapper/GanttBarWrapper.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import KeyPropType from 'prop-types/Key.prop-type'
 
 import './GanttBarWrapper.scss'
-import { BAR_HEIGHT, BAR_SPACER } from 'util/Constant/BaseConstantList'
+import { GANTT_BAR_HEIGHT, GANTT_BAR_SPACER } from 'util/Constant/BaseConstantList'
 
 function GanttBarWrapper({
   barHeight,
@@ -14,7 +14,7 @@ function GanttBarWrapper({
   i,
   offset,
 }) {
-  const fullHeight = BAR_HEIGHT + BAR_SPACER
+  const fullHeight = GANTT_BAR_HEIGHT + GANTT_BAR_SPACER
 
   return (
     <li
@@ -31,8 +31,8 @@ function GanttBarWrapper({
 }
 
 GanttBarWrapper.defaultProps = {
-  barHeight: BAR_HEIGHT,
-  barSpacer: BAR_SPACER,
+  barHeight: GANTT_BAR_HEIGHT,
+  barSpacer: GANTT_BAR_SPACER,
   i: 1,
   offset: 35,
 }

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 .sb-show-main.sb-show-main.sb-show-main {
   padding: 0;

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.example-data.js
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.example-data.js
@@ -59,7 +59,7 @@ export const UserChoiceGroupedExampleData = [
 export const UserChoiceGroupingListAfterStatMapping = [{
   10: {
     count: 3,
-    label: 10,
+    label: 'Mild symptom 2 - 10',
     max: 31,
     mda: 7,
     mean: 22,
@@ -70,12 +70,11 @@ export const UserChoiceGroupingListAfterStatMapping = [{
     std: 6.9761,
     tone: null
   },
-  label: '10 3'
 },
 {
   '10-19': {
     count: 20,
-    label: '10-19',
+    label: 'Mild symptom 2 - 10-19',
     max: 43,
     mda: 3,
     mean: 21.9,
@@ -84,13 +83,13 @@ export const UserChoiceGroupingListAfterStatMapping = [{
     quantile: [14, 15.5, 17.5, 19.5, 20, 20, 21.5, 26.5, 37.5],
     skewness: 1.3498,
     std: 8.4137,
-    tone: null},
-  label: '10-19 20'
+    tone: null
+  },
 },
 {
   '20-29': {
     count: 2,
-    label: '20-29',
+    label: 'Mild symptom 2 - 20-29',
     max: 20,
     mda: 2.5,
     mean: 17.5,
@@ -101,12 +100,11 @@ export const UserChoiceGroupingListAfterStatMapping = [{
     std: 2.5,
     tone: null
   },
-  label: '20-29 2'
 },
 {
   '30-39': {
     count: 2,
-    label: '30-39',
+    label: 'Mild symptom 2 - 30-39',
     max: 31,
     mda: 5,
     mean: 26,
@@ -117,12 +115,11 @@ export const UserChoiceGroupingListAfterStatMapping = [{
     std: 5,
     tone: null
   },
-  label: '30-39 2'
 },
 {
   '50-59': {
     count: 1,
-    label: '50-59',
+    label: 'Mild symptom 2 - 50-59',
     max: 20,
     mda: 0,
     mean: 20,
@@ -133,7 +130,6 @@ export const UserChoiceGroupingListAfterStatMapping = [{
     std: 0,
     tone: null
   },
-  label: '50-59 1'
 }]
 
 export const InteractiveGanttExampleData = [{
@@ -220,7 +216,7 @@ export const InteractiveGanttExampleData = [{
 export const InteractiveGanttFullyProcessedExampleData = [{
   10: {
     count: 3,
-    label: '10',
+    label: 'Mild symptom 2 - 10',
     max: 31,
     mda: 7,
     mean: 22,
@@ -231,12 +227,11 @@ export const InteractiveGanttFullyProcessedExampleData = [{
     std: 6.9761,
     tone: null
   },
-  label: '10 3'
 },
 {
   '10-19': {
     count: 15,
-    label: '10-19',
+    label: 'Mild symptom 2 - 10-19',
     max: 43,
     mda: 4,
     mean: 22.067,
@@ -247,12 +242,11 @@ export const InteractiveGanttFullyProcessedExampleData = [{
     std: 9.2265,
     tone: null
   },
-  label: '10-19 15'
 },
 {
   '20-29': {
     count: 2,
-    label: '20-29',
+    label: 'Mild symptom 2 - 20-29',
     max: 20,
     mda: 2.5,
     mean: 17.5,
@@ -263,12 +257,11 @@ export const InteractiveGanttFullyProcessedExampleData = [{
     std: 2.5,
     tone: null
   },
-  label: '20-29 2'
 },
 {
   '30-39': {
     count: 2,
-    label: '30-39',
+    label: 'Mild symptom 2 - 30-39',
     max: 31,
     mda: 5,
     mean: 26,
@@ -279,12 +272,11 @@ export const InteractiveGanttFullyProcessedExampleData = [{
     std: 5,
     tone: null
   },
-  label: '30-39 2'
 },
 {
   '50-59': {
     count: 1,
-    label: '50-59',
+    label: 'Mild symptom 2 - 50-59',
     max: 20,
     mda: 0,
     mean: 20,
@@ -295,5 +287,4 @@ export const InteractiveGanttFullyProcessedExampleData = [{
     std: 0,
     tone: null
   },
-  label: '50-59 1'
 }]

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.example-data.js
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.example-data.js
@@ -59,7 +59,7 @@ export const UserChoiceGroupedExampleData = [
 export const UserChoiceGroupingListAfterStatMapping = [{
   10: {
     count: 3,
-    label: 'Mild symptom 2 - 10',
+    label: 'Mild symptom 2 [@10]',
     max: 31,
     mda: 7,
     mean: 22,
@@ -74,7 +74,7 @@ export const UserChoiceGroupingListAfterStatMapping = [{
 {
   '10-19': {
     count: 20,
-    label: 'Mild symptom 2 - 10-19',
+    label: 'Mild symptom 2 [@10-19]',
     max: 43,
     mda: 3,
     mean: 21.9,
@@ -89,7 +89,7 @@ export const UserChoiceGroupingListAfterStatMapping = [{
 {
   '20-29': {
     count: 2,
-    label: 'Mild symptom 2 - 20-29',
+    label: 'Mild symptom 2 [@20-29]',
     max: 20,
     mda: 2.5,
     mean: 17.5,
@@ -104,7 +104,7 @@ export const UserChoiceGroupingListAfterStatMapping = [{
 {
   '30-39': {
     count: 2,
-    label: 'Mild symptom 2 - 30-39',
+    label: 'Mild symptom 2 [@30-39]',
     max: 31,
     mda: 5,
     mean: 26,
@@ -119,7 +119,7 @@ export const UserChoiceGroupingListAfterStatMapping = [{
 {
   '50-59': {
     count: 1,
-    label: 'Mild symptom 2 - 50-59',
+    label: 'Mild symptom 2 [@50-59]',
     max: 20,
     mda: 0,
     mean: 20,
@@ -216,7 +216,7 @@ export const InteractiveGanttExampleData = [{
 export const InteractiveGanttFullyProcessedExampleData = [{
   10: {
     count: 3,
-    label: 'Mild symptom 2 - 10',
+    label: 'Mild symptom 2 [@10]',
     max: 31,
     mda: 7,
     mean: 22,
@@ -231,7 +231,7 @@ export const InteractiveGanttFullyProcessedExampleData = [{
 {
   '10-19': {
     count: 15,
-    label: 'Mild symptom 2 - 10-19',
+    label: 'Mild symptom 2 [@10-19]',
     max: 43,
     mda: 4,
     mean: 22.067,
@@ -246,7 +246,7 @@ export const InteractiveGanttFullyProcessedExampleData = [{
 {
   '20-29': {
     count: 2,
-    label: 'Mild symptom 2 - 20-29',
+    label: 'Mild symptom 2 [@20-29]',
     max: 20,
     mda: 2.5,
     mean: 17.5,
@@ -261,7 +261,7 @@ export const InteractiveGanttFullyProcessedExampleData = [{
 {
   '30-39': {
     count: 2,
-    label: 'Mild symptom 2 - 30-39',
+    label: 'Mild symptom 2 [@30-39]',
     max: 31,
     mda: 5,
     mean: 26,
@@ -276,7 +276,7 @@ export const InteractiveGanttFullyProcessedExampleData = [{
 {
   '50-59': {
     count: 1,
-    label: 'Mild symptom 2 - 50-59',
+    label: 'Mild symptom 2 [@50-59]',
     max: 20,
     mda: 0,
     mean: 20,

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
@@ -5,7 +5,7 @@ import GanttScale from 'sections/GanttScale/GanttScale'
 import GanttBarList from 'sections/GanttBarList/GanttBarList'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
-import { calcScale } from 'util/UtilGanttBarList/UtilGanttBarList'
+import { calcGanttListHeight, calcScale } from 'util/UtilGanttBarList/UtilGanttBarList'
 import { calcInteractiveGantt } from 'util/UtilGanttBarList/UtilInteractiveGantt'
 
 import './InteractiveGantt.scss'
@@ -20,6 +20,8 @@ function InteractiveGantt({
   const [currentGroupBy, setCurrentGroupBy] = useState('mild_symptom_1')
 
   const statDataList = calcInteractiveGantt({ currentGroupBy, currentResponse, data })
+
+  const ganttHeight = calcGanttListHeight({ statDataList })
 
   const { maxOfAll, scale } = calcScale({ statDataList })
 
@@ -37,10 +39,11 @@ function InteractiveGantt({
           <div className='interactive-gantt__scale'>
             <GanttScale
               ariaLabel='interactive statistics list'
-              scale={scale}
-              setGanttTogglelList={setGanttTogglelList}
+              ganttHeight={ganttHeight}
               ganttToggleList={ganttToggleList}
               ganttToggleListIsActive
+              scale={scale}
+              setGanttTogglelList={setGanttTogglelList}
             />
           </div>
           <GanttBarList

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
@@ -28,13 +28,15 @@ function InteractiveGantt({
   return (
     <SubPageWrapper>
       <div className='interactive-gantt row-layout space-children--wide'>
-        <AxisSelector
-          align='right'
-          axis='stats'
-          currentAxisSelection={currentResponse}
-          disabledSelection={currentGroupBy}
-          setCurrentAxisSelection={setCurrentResponse}
-        />
+        <div className='interactive-gantt__bar-selector'>
+          <AxisSelector
+            align='right'
+            axis='stats'
+            currentAxisSelection={currentResponse}
+            disabledSelection={currentGroupBy}
+            setCurrentAxisSelection={setCurrentResponse}
+          />
+        </div>
         <figure className='interactive-gantt__data'>
           <div className='interactive-gantt__scale'>
             <GanttScale

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.scss
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.scss
@@ -2,6 +2,11 @@
 
 .interactive-gantt {
   width: 100%;
+  &__bar-selector {
+    &.interactive-gantt__bar-selector {
+      @include self-space-row-remove-border();
+    }
+  }
   &__data {
     width: 100%;
     position: relative;

--- a/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
@@ -5,6 +5,7 @@ import TimeLineStatChart from 'sections/GanttBarList/GanttBarList'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
 import { calcPathogenesisGantt } from 'util/UtilGanttBarList/UtilPathogenesisGantt'
+import { calcGanttListHeight } from 'util/UtilGanttBarList/UtilGanttBarList'
 
 import './PathogenesisGantt.scss'
 
@@ -18,16 +19,19 @@ function PathogenesisGantt({
 
   const scale = { totalSteps: 5, stepDivision: 60 }
 
+  const ganttHeight = calcGanttListHeight({ statDataList })
+
   return (
     <SubPageWrapper>
       <figure className='pathogenesis-gantt column-layout space-children--wide-column'>
         <div className='pathogenesis-gantt__scale'>
           <GanttScale
             ariaLabel='clinical response timings'
-            scale={scale}
-            setGanttTogglelList={setGanttTogglelList}
+            ganttHeight={ganttHeight}
             ganttToggleList={ganttToggleList}
             ganttToggleListIsActive
+            scale={scale}
+            setGanttTogglelList={setGanttTogglelList}
           />
         </div>
         <TimeLineStatChart

--- a/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
 import GanttScale from 'sections/GanttScale/GanttScale'
-import TimeLineStatChart from 'sections/GanttBarList/GanttBarList'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
-import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
+import TimeLineStatChart from 'sections/GanttBarList/GanttBarList'
 import { calcPathogenesisGantt } from 'util/UtilGanttBarList/UtilPathogenesisGantt'
 import { calcGanttListHeight } from 'util/UtilGanttBarList/UtilGanttBarList'
+import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
 
 import './PathogenesisGantt.scss'
 

--- a/gui/src/sections/AxisSelector/AxisSelector.scss
+++ b/gui/src/sections/AxisSelector/AxisSelector.scss
@@ -50,7 +50,7 @@ $axis-selector__full-width: $axis-selector__base-width + $padding--medium;
 
 
   &.left {
-    border-left: 1px solid var(--grey--lightest);
+    border-left: 1px solid var(--green--dark);
 
     .axis-selector__heading {
       text-align: left;
@@ -77,7 +77,7 @@ $axis-selector__full-width: $axis-selector__base-width + $padding--medium;
   }
 
   &.right {
-    border-right: 1px solid var(--grey--lightest);
+    border-right: 1px solid var(--green--dark);
 
     .axis-selector__open-button {
       left: $axis-selector__full-width;

--- a/gui/src/sections/GanttScale/GanttScale.jsx
+++ b/gui/src/sections/GanttScale/GanttScale.jsx
@@ -24,8 +24,6 @@ function GanttScale({
 }) {
   const { stepDivision, totalSteps } = calcScaleToFitUI({ scale })
 
-  const totalDivisions = totalSteps * stepDivision
-
   return (
     <ol
       aria-label={i18next.t('GanttScale.scaleFor', { ariaLabel })}
@@ -33,11 +31,9 @@ function GanttScale({
       style={style}
     >
       { ramda.range(0, totalSteps + 1).map(step => {
-        const lastStep = step === totalSteps
-        const scalePerc = step / totalSteps * 100
-        const positionScaleStep = { left: `calc(${scalePerc}% ${lastStep ? '- 18px' : '- 1px'})`}
-        const positionScaleLine = { left: `calc(${scalePerc}% - 1px)`, height: lineHeight || '149vh' }
-        const positionScaleSubStep = { left: `calc(${scalePerc}% ${lastStep ? '- 55px' : '+ 30px'})`}
+        const scalePerc = (step / totalSteps * 100).toPrecision(5)
+        const positionScaleStep = { left: `calc(${scalePerc}% + 1px)`}
+        const positionScaleLine = { left: `calc(${scalePerc}% - 1px)`, height: `${ganttHeight}px` }
 
         return (
           <li key={step} >
@@ -46,14 +42,7 @@ function GanttScale({
               key='step'
               style={positionScaleStep}
             >
-              {step}
-            </span>
-            <span
-              className='gantt-scale__label gantt-scale__sub-label'
-              key='stepDivision'
-              style={positionScaleSubStep}
-            >
-              {stepDivision}
+              {step * stepDivision}
             </span>
             <div
               className={`gantt-scale__line`}
@@ -72,13 +61,6 @@ function GanttScale({
     </ol>
   )
 }
-      // <li key='all-steps'>
-      //   <span
-      //     className='gantt-scale__label gantt-scale__total-label'
-      //   >
-      //     {totalDivisions}
-      //   </span>
-      // </li>
 
 GanttScale.defaultProps = {
   scale: SCALE_DEFAULT,

--- a/gui/src/sections/GanttScale/GanttScale.jsx
+++ b/gui/src/sections/GanttScale/GanttScale.jsx
@@ -31,8 +31,11 @@ function GanttScale({
       style={style}
     >
       { ramda.range(0, totalSteps + 1).map(step => {
+        const lastStep = step === totalSteps
         const scalePerc = (step / totalSteps * 100).toPrecision(5)
-        const positionScaleStep = { left: `calc(${scalePerc}% + 1px)`}
+        const positionScaleStep = lastStep
+          ? { right: `1px` }
+          : { left: `calc(${scalePerc}% + 1px)`}
         const positionScaleLine = { left: `calc(${scalePerc}% - 1px)`, height: `${ganttHeight}px` }
 
         return (

--- a/gui/src/sections/GanttScale/GanttScale.jsx
+++ b/gui/src/sections/GanttScale/GanttScale.jsx
@@ -14,13 +14,13 @@ import './GanttScale.scss'
 
 function GanttScale({
   ariaLabel,
-  lineHeight,
-  scale,
-  showBarControls,
-  style,
-  setGanttTogglelList,
   ganttToggleList,
   ganttToggleListIsActive,
+  ganttHeight,
+  scale,
+  setGanttTogglelList,
+  showBarControls,
+  style,
 }) {
   const { stepDivision, totalSteps } = calcScaleToFitUI({ scale })
 
@@ -69,29 +69,30 @@ function GanttScale({
           ganttToggleList={ganttToggleList}
         />
       </li>
-      <li key='all-steps'>
-        <span
-          className='gantt-scale__label gantt-scale__total-label'
-        >
-          {totalDivisions}
-        </span>
-      </li>
     </ol>
   )
 }
+      // <li key='all-steps'>
+      //   <span
+      //     className='gantt-scale__label gantt-scale__total-label'
+      //   >
+      //     {totalDivisions}
+      //   </span>
+      // </li>
 
 GanttScale.defaultProps = {
   scale: SCALE_DEFAULT,
   showBarControls: true,
+  ganttHeight: '149vh',
   ganttToggleList: GANTT_TOGGLE_LIST,
   ganttToggleListIsActive: true,
 }
 
 GanttScale.propTypes = {
   ariaLabel: PropTypes.string.isRequired,
+  ganttHeight: NumberOrStringPropType,
   ganttToggleList: GanttToggleListPropType,
   ganttToggleListIsActive: PropTypes.bool,
-  lineHeight: NumberOrStringPropType,
   scale: GanttScalePropType,
   setGanttToggleList: PropTypes.func,
   showBarControls: PropTypes.bool,

--- a/gui/src/sections/GanttScale/GanttScale.scss
+++ b/gui/src/sections/GanttScale/GanttScale.scss
@@ -1,7 +1,7 @@
 .gantt-scale {
   width: 100%;
   height: 2px;
-  background-color: var(--grey--dark);
+  background-color: var(--grey--light);
   position: relative;
   top: var(--spacing--narrow);
   &__line {
@@ -19,7 +19,6 @@
     font-weight: bold;
     padding: var(--padding--small-tiny);
     position: absolute;
-    left: 2px;
     top: 2px;
   }
   &__total-label {

--- a/gui/src/sections/GanttScale/GanttScale.scss
+++ b/gui/src/sections/GanttScale/GanttScale.scss
@@ -35,7 +35,7 @@
   }
   &__bar-toggle-interface {
     position: absolute;
-    top: -35px;
+    top: -60px;
     width: 100%;
     box-sizing: border-box;
   }

--- a/gui/src/sections/GanttScale/GanttScale.scss
+++ b/gui/src/sections/GanttScale/GanttScale.scss
@@ -13,19 +13,13 @@
     z-index: var(--step-right-back);
   }
   &__label {
-    background-color: var(--grey--dark);
-    color: var(--white);
-    font-size: var(--font-size--medium-large);
-    font-weight: bold;
-    margin-right: -9px;
-    padding: var(--padding--small-tiny);
-    position: absolute;
-    top: 2px;
-    z-index: var(--step-right-forward);
-  }
-  &__sub-label {
     background-color: var(--blue--light);
     color: var(--black);
+    font-size: var(--font-size--medium-large);
+    font-weight: bold;
+    padding: var(--padding--small-tiny);
+    position: absolute;
+    left: 2px;
     top: 2px;
   }
   &__total-label {

--- a/gui/src/sections/GanttScale/GanttScale.stories.js
+++ b/gui/src/sections/GanttScale/GanttScale.stories.js
@@ -8,6 +8,7 @@ export default {
 
 const baseGanttScaleProps = {
   ariaLabel: 'Storybook graph',
+  ganttHeight: '300',
   scale: {
     totalSteps: 6,
     stepDivision: 60,
@@ -16,77 +17,151 @@ const baseGanttScaleProps = {
 
 export const Primary = {
   render: () => {
-    return (<StoryBookPaddedWrapper><GanttScale { ...baseGanttScaleProps } /></StoryBookPaddedWrapper>)
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...baseGanttScaleProps } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const BigDetailedSteps = {
   render: () => {
-    const props = { scale: { stepDivision: 257, totalSteps: 2 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 257, totalSteps: 2 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const LotsOfTinyStepsIsProblematic = {
   render: () => {
-    const props = { scale: { stepDivision: 3, totalSteps: 120 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 3, totalSteps: 120 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const MaxStepsForNow = {
   render: () => {
-    const props = { scale: { stepDivision: 3, totalSteps: 20 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 3, totalSteps: 20 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const StepsWithHugeDivisions = {
   render: () => {
-    const props = { scale: { stepDivision: 12000, totalSteps: 5 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 12000, totalSteps: 5 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const Test21 = {
   render: () => {
-    const props = { scale: { stepDivision: 50, totalSteps: 3 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 50, totalSteps: 3 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 
 export const Test200 = {
   render: () => {
-    const props = { scale: { stepDivision: 50, totalSteps: 20 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 50, totalSteps: 20 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const Test201 = {
   render: () => {
-    const props = { scale: { stepDivision: 5000, totalSteps: 3 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 5000, totalSteps: 3 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const Test2000 = {
   render: () => {
-    const props = { scale: { stepDivision: 5000, totalSteps: 20 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 5000, totalSteps: 20 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const Test2001 = {
   render: () => {
-    const props = { scale: { stepDivision: 50000, totalSteps: 3 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 50000, totalSteps: 3 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };
 
 export const Test20000 = {
   render: () => {
-    const props = { scale: { stepDivision: 50000, totalSteps: 20 } }
-    return (<StoryBookPaddedWrapper><GanttScale { ...props } /></StoryBookPaddedWrapper>)
+    const props = {
+      ...baseGanttScaleProps,
+      scale: { stepDivision: 50000, totalSteps: 20 }
+    }
+    return (
+      <StoryBookPaddedWrapper>
+        <GanttScale { ...props } />
+      </StoryBookPaddedWrapper>
+    )
   },
 };

--- a/gui/src/sections/GanttScale/GanttScale.test.js
+++ b/gui/src/sections/GanttScale/GanttScale.test.js
@@ -12,7 +12,10 @@ test('GanttScale', async () => {
   )
 
   expect(screen.getByLabelText('Scale for test graph')).toBeTruthy()
-  expect(screen.getByText('1')).toBeTruthy()
+  expect(screen.getByText('0')).toBeTruthy()
+  expect(screen.getByText('5')).toBeTruthy()
+  expect(screen.getByText('10')).toBeTruthy()
+  expect(screen.getByText('15')).toBeTruthy()
+  expect(screen.getByText('20')).toBeTruthy()
   expect(screen.getByText('25')).toBeTruthy()
-  expect(screen.getAllByText('5').length).toEqual(7)
 })

--- a/gui/src/util/Constant/BaseConstantList.js
+++ b/gui/src/util/Constant/BaseConstantList.js
@@ -2,57 +2,6 @@ import { keys } from 'ramda'
 
 /***********************************/
 /*
- * Correlation heatmap
- */
-export const CORRELATION_HEATMAP_FIELD_LIST = [
-  // 0
-  'care_technique_1', 'care_equipment_1', 'care_technique_2', 'care_technique_3', 'care_technique_4',
-  'care_technique_5', 'care_equipment_2', 'care_equipment_3', 'care_technique_6', 'care_technique_7',
-  'care_equipment_4',
-
-  // 11
-  'patient_weight',
-  'presented_gender',
-  'source_country',
-  'consultant_doctor',
-  'event_count',
-  'care_site',
-
-  // 17
-  'etiology',
-  'outcome',
-  'outcome_type',
-  'care_error_level',
-  'overall_patient_rating',
-  'pathological_severity',
-  'pathogenesis_duration',
-  'pathological_event_duration',
-  'outlier',
-
-  // 26
-  'intro_symptom_start', 'intro_symptom_end', 'intro_symptom_duration',
-  'mild_symptom_1', 'mild_symptom_1_1_end', 'mild_symptom_1_2', 'mild_symptom_1_duration',
-  'mild_symptom_2', 'mild_symptom_2_duration',
-
-  // 35
-  'first_prime_symptom', 'first_prime_symptom_type',
-  'prime_symptom_1', 'prime_symptom_1_duration', 'prime_symptom_any',
-  'prime_symptom_2', 'prime_symptom_2_duration',
-  'prime_symptom_3', 'prime_symptom_3_duration',
-  'prime_symptom_duration', 'prime_symptom_level', 'prime_symptom_proportion',
-
-  // 48
-  'recovery_duration', 'recovery_proportion',
-
-  // 50
-  'fatal_symptom_1', 'fatal_symptom_2',
-  'death_response_1', 'death_response_2', 'slight_death_response_1', 'slight_death_response_2',
-  'time_of_death',
-]
-
-
-/***********************************/
-/*
  * Errors
  */
 export const I18N_ERROR_KEY = 'ErrorList'

--- a/gui/src/util/Constant/BaseConstantList.js
+++ b/gui/src/util/Constant/BaseConstantList.js
@@ -142,8 +142,8 @@ export const HYPOTHESIS_SYMPTOM_X_Y = {
 /*
  * Gantt Bars
  */
-export const BAR_HEIGHT = 44
-export const BAR_SPACER = 29
+export const GANTT_BAR_HEIGHT = 44
+export const GANTT_BAR_SPACER = 29
 export const PRECISION = 5
 export const QUANTILE_LIST = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 export const QUANTILE_LIST_LONG = QUANTILE_LIST

--- a/gui/src/util/UtilGanttBarList/UtilGanttBarList.js
+++ b/gui/src/util/UtilGanttBarList/UtilGanttBarList.js
@@ -9,8 +9,26 @@ import {
   medianAbsoluteDeviation,
 } from 'simple-statistics'
 
-import { PRECISION, QUANTILE_LIST } from 'util/Constant/BaseConstantList'
+import {
+  GANTT_BAR_HEIGHT,
+  GANTT_BAR_SPACER,
+  PRECISION,
+  QUANTILE_LIST
+} from 'util/Constant/BaseConstantList'
 import { throwError } from 'util/Util/Util'
+
+
+export function calcGanttListHeight({ statDataList = [] } = {}) {
+  const fullBarHeight = GANTT_BAR_HEIGHT + GANTT_BAR_SPACER
+
+  return (
+    statDataList.length
+    +
+    1
+  )
+  *
+  fullBarHeight
+}
 
 
 export function calcScale({ statDataList = [] } = {}) {

--- a/gui/src/util/UtilGanttBarList/UtilGanttBarList.test.js
+++ b/gui/src/util/UtilGanttBarList/UtilGanttBarList.test.js
@@ -1,4 +1,12 @@
-import { calcScale, getStatBase, fullStatBase, mapToGanttBars } from './UtilGanttBarList'
+import {
+  calcGanttListHeight,
+  calcScale,
+  fullStatBase,
+  getStatBase,
+  mapToGanttBars,
+} from './UtilGanttBarList'
+
+import { GANTT_BAR_HEIGHT, GANTT_BAR_SPACER } from 'util/Constant/BaseConstantList'
 
 const quantile = [1, 5, 5, 9, 30, 51, 53, 53, 58]
 
@@ -14,6 +22,24 @@ const statBaseZeroes = { max: 0, mean: 0, median: 0, min: 0 }
 const vals = [1, 5, 9, 53, 58, 51]
 
 const i18nBase = 'ReactTestLibrary'
+
+
+/*
+ * calcGanttListHeight()
+ */
+test('calcGanttListHeight() with nothing', () => {
+  expect(calcGanttListHeight()).toEqual(GANTT_BAR_HEIGHT + GANTT_BAR_SPACER)
+})
+test('calcGanttListHeight() with empty array', () => {
+  expect(calcGanttListHeight({ statDataList: [] })).toEqual(GANTT_BAR_HEIGHT + GANTT_BAR_SPACER)
+})
+test('calcGanttListHeight() with array with contents', () => {
+  const statDataList = [1, 2, 3]
+  const result = (GANTT_BAR_HEIGHT + GANTT_BAR_SPACER) * (statDataList.length + 1)
+
+  expect(calcGanttListHeight({ statDataList })).toEqual(result)
+})
+
 
 
 /*

--- a/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.js
+++ b/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.js
@@ -1,3 +1,4 @@
+import i18next from 'util/i18next/i18next'
 import { filter, map, pipe, toPairs, type } from 'ramda'
 
 import { throwError } from 'util/Util/Util'
@@ -18,32 +19,35 @@ export function calcInteractiveGantt({ currentGroupBy, currentResponse, data }) 
 
   return pipe(
     groupByResponse({ currentGroupBy, currentResponse }),
-    map(userChoiceGroupedStatMapper({ currentResponse })),
+    map(userChoiceGroupedStatMapper({ currentResponse, currentGroupBy })),
     filter(statSet => toPairs(statSet)[0][1].count > 0)
   )(data)
 }
 
 
-export function userChoiceGroupedStatMapper({ currentResponse }) {
+export function userChoiceGroupedStatMapper({ currentResponse, currentGroupBy }) {
   throwError({
     check: type(currentResponse) === 'String',
     i18nKey: 'userChoiceStatMapper',
   })
+
+  const clinicalPrefix = i18next.t(`CommonClinicalResponses.${currentGroupBy}`)
 
   return ([k, data]) => {
     const vals = calcValsForGrouping({ currentResponse, data })
     const count = vals.length
     const statBase = getStatBase({ count, vals })
 
-    return {
-      ...fullStatBase({
-        count,
-        vals,
-        statBase,
-        k,
-        tone: null,
-      }),
-      label: `${k} ${count}`,
-    }
+    const mappedStatList = fullStatBase({
+      count,
+      vals,
+      statBase,
+      k,
+      tone: null,
+    })
+
+    mappedStatList[k].label = `${clinicalPrefix} - ${k}`
+
+    return mappedStatList
   }
 }

--- a/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.js
+++ b/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.js
@@ -46,7 +46,7 @@ export function userChoiceGroupedStatMapper({ currentResponse, currentGroupBy })
       tone: null,
     })
 
-    mappedStatList[k].label = `${clinicalPrefix} - ${k}`
+    mappedStatList[k].label = `${clinicalPrefix} [@${k}]`
 
     return mappedStatList
   }

--- a/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.test.js
+++ b/gui/src/util/UtilGanttBarList/UtilInteractiveGantt.test.js
@@ -55,7 +55,8 @@ test('userChoiceGroupedStatMapper() returns good data if everything is provided'
   expect(
     UserChoiceGroupedExampleData.map(
       userChoiceGroupedStatMapper({
-        currentResponse: 'prime_symptom_1'
+        currentGroupBy: 'mild_symptom_2',
+        currentResponse: 'prime_symptom_1',
       })
     )
   ).toEqual(UserChoiceGroupingListAfterStatMapping)


### PR DESCRIPTION
* garden: keep it onscreen with no side-ways scroll
* update axis selector border - using the dark green matches the button and is a bit more distinct as an edge
* move the Gantt toggle buttons - cleaner spacing
* added the selected clinical response to each of the bar labels
* old screen consts are removed
* Gantt height calc improved
* labeled Gantt consts better
* used consts and a tested util to make a calculation on the graph height
* story-book uses the height value
* final number is positioned on graph

