### PR TITLE
feat 29 make the site remember selections

### DIFF
--- a/gui/src/components/LanguageToggle/LanguageToggle.jsx
+++ b/gui/src/components/LanguageToggle/LanguageToggle.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import Button from 'components/Button/Button'
+import { setLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import './LanguageToggle.scss'
 
@@ -20,7 +21,7 @@ function LanguageToggleButton({ languageKey }) {
       label={i18next.t(`${i18nBase}.${languageKey}`)}
       onClick={() => {
         i18next.changeLanguage(languageKey)
-        localStorage.setItem('currentLanguage', languageKey)
+        setLocalStorage({ k: 'currentLanguage', v: languageKey })
       }}
     />
   )

--- a/gui/src/screens/AntiBiasToolKit/AntiBiasToolKit.jsx
+++ b/gui/src/screens/AntiBiasToolKit/AntiBiasToolKit.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNav from 'sections/SecondaryNav/SecondaryNav'
 import SecondaryNavButtonList from 'components/SecondaryNavButtonList/SecondaryNavButtonList'
+import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
 
 import BiasedCorrelationSim from './panel-list/BiasedCorrelationSim/BiasedCorrelationSim'
 import BiasedJudgementSim from './panel-list/BiasedJudgementSim/BiasedJudgementSim'
@@ -12,7 +13,8 @@ import BiasedTimingSim from './panel-list/BiasedTimingSim/BiasedTimingSim'
 const i18nBase = 'AntiBiasToolKit'
 
 function AntiBiasToolKit({ data }) {
-  const [antiBiasToolKitPanel, setAntiBiasToolKitPanel] = useState('correlation')
+  const currentPanel = secondaryNavLocalStorage({ def: 'correlation', k: i18nBase })
+  const [antiBiasToolKitPanel, setAntiBiasToolKitPanel] = useState(currentPanel)
 
   const {
     biased_test_cases: biasedTestCases,

--- a/gui/src/screens/AntiBiasToolKit/panel-list/BiasedCorrelationSim/BiasedCorrelationSim.jsx
+++ b/gui/src/screens/AntiBiasToolKit/panel-list/BiasedCorrelationSim/BiasedCorrelationSim.jsx
@@ -3,18 +3,21 @@ import React, { useState } from 'react'
 import { shuffle } from 'simple-statistics'
 import { range } from 'ramda'
 
-import { BAD_CORRELATION_SIM_ERROR_LIST } from 'util/Constant/BaseConstantList'
 import DataAdjusterButtonList from 'sections/DataAdjusterButtonList/DataAdjusterButtonList'
-import ScatterDataPropType from 'prop-types/ScatterData.prop-type'
 import ScatterChart from 'sections/ScatterChart/ScatterChart'
+import ScatterDataPropType from 'prop-types/ScatterData.prop-type'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
+import { BAD_CORRELATION_SIM_ERROR_LIST } from 'util/Constant/BaseConstantList'
+import { dataAdjusterLocalStorage } from 'util/UtilLocalStorage/UtilDataAdjuster'
+import { setLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import './BiasedCorrelationSim.scss'
 
 const i18nBase = 'BiasedCorrelationSim'
 
 function BiasedCorrelationSim({ antiBiasToolKitData: scatterData }) {
-  const [timingError, setTimingError] = useState(0)
+  const persistedCorrelationError = dataAdjusterLocalStorage({ k: 'biasCorrelation' })
+  const [timingError, setTimingError] = useState(persistedCorrelationError)
   if (!scatterData) { return null }
 
   function mappedPointFn ({
@@ -49,6 +52,7 @@ function BiasedCorrelationSim({ antiBiasToolKitData: scatterData }) {
     onClickHandler: ({ adjustBy }) =>
       () => {
         setTimingError(adjustBy)
+        setLocalStorage({ k: 'biasCorrelation', v: adjustBy })
       },
     selectedFn: ({ curr }) => timingError === curr
   }

--- a/gui/src/screens/AntiBiasToolKit/panel-list/BiasedTimingSim/BiasedTimingSim.jsx
+++ b/gui/src/screens/AntiBiasToolKit/panel-list/BiasedTimingSim/BiasedTimingSim.jsx
@@ -2,10 +2,15 @@ import PropTypes from 'prop-types'
 import i18next from 'util/i18next/i18next'
 import React, { useState } from 'react'
 
-import { BAD_TIMING_SIM_ERROR_LIST, PRIME_SYMPTOM_BLOCK_SIZE } from 'util/Constant/BaseConstantList'
 import DataAdjusterButtonList from 'sections/DataAdjusterButtonList/DataAdjusterButtonList'
 import PrimeSymptomHistogram from 'sections/PrimeSymptomHistogram/PrimeSymptomHistogram'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
+import {
+  BAD_TIMING_SIM_ERROR_LIST,
+  PRIME_SYMPTOM_BLOCK_SIZE,
+  PRIME_SYMPTOM_HISTOGRAM_HEIGHT,
+} from 'util/Constant/BaseConstantList'
+import { primeSymptomAntiBiasLocalStorage } from 'util/UtilLocalStorage/UtilPrimeSymptom'
 
 import './BiasedTimingSim.scss'
 
@@ -48,7 +53,9 @@ function BiasedTimingSim({ antiBiasToolKitData }) {
       <PrimeSymptomHistogram
         badTimingError={badTimingError}
         blockSize={PRIME_SYMPTOM_BLOCK_SIZE}
-        histogramHeight={56}
+        localStorageFn={primeSymptomAntiBiasLocalStorage}
+        localStorageKey='primeSymptomAntiBias'
+        histogramHeight={PRIME_SYMPTOM_HISTOGRAM_HEIGHT}
         primeSymptomData={antiBiasToolKitData}
         timingError={timingError}
       />

--- a/gui/src/screens/AntiBiasToolKit/panel-list/BiasedTimingSim/BiasedTimingSim.jsx
+++ b/gui/src/screens/AntiBiasToolKit/panel-list/BiasedTimingSim/BiasedTimingSim.jsx
@@ -10,15 +10,19 @@ import {
   PRIME_SYMPTOM_BLOCK_SIZE,
   PRIME_SYMPTOM_HISTOGRAM_HEIGHT,
 } from 'util/Constant/BaseConstantList'
+import { dataAdjusterLocalStorage } from 'util/UtilLocalStorage/UtilDataAdjuster'
 import { primeSymptomAntiBiasLocalStorage } from 'util/UtilLocalStorage/UtilPrimeSymptom'
+import { setLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import './BiasedTimingSim.scss'
 
 const i18nBase = 'BiasedTimingSim'
 
 function BiasedTimingSim({ antiBiasToolKitData }) {
-  const [timingError, setTimingError] = useState(0)
-  const [badTimingError, setBiasedTimingError] = useState(0)
+  const persistedTimingError = dataAdjusterLocalStorage({ k: 'biasTiming' })
+  const persistedBadTimingError = dataAdjusterLocalStorage({ k: 'badBiasTiming' })
+  const [timingError, setTimingError] = useState(persistedTimingError)
+  const [badTimingError, setBiasedTimingError] = useState(persistedBadTimingError)
   if (!antiBiasToolKitData) { return null }
 
   const commonAdjusterProps = {
@@ -38,14 +42,24 @@ function BiasedTimingSim({ antiBiasToolKitData }) {
         <DataAdjusterButtonList
           {...commonAdjusterProps}
           listLabel={i18next.t(`${i18nBase}.biased`)}
-          onClickHandler={({ adjustBy }) => () => { setTimingError(adjustBy); setBiasedTimingError(0) }}
+          onClickHandler={({ adjustBy }) => () => {
+            setTimingError(adjustBy)
+            setBiasedTimingError(0)
+            setLocalStorage({ k: 'badBiasTiming', v: 0 })
+            setLocalStorage({ k: 'biasTiming', v: adjustBy })
+          }}
           selectedFn={({ curr }) => timingError === curr && badTimingError === 0}
         />
         <div className='hide'>
           <DataAdjusterButtonList
             {...commonAdjusterProps}
             listLabel={i18next.t(`${i18nBase}.veryBiased`)}
-            onClickHandler={({ adjustBy }) => () => { setBiasedTimingError(adjustBy); setTimingError(0) }}
+            onClickHandler={({ adjustBy }) => () => {
+              setBiasedTimingError(adjustBy)
+              setTimingError(0)
+              setLocalStorage({ k: 'biasTiming', v: 0 })
+              setLocalStorage({ k: 'badBiasTiming', v: adjustBy })
+            }}
             selectedFn={({ curr }) => badTimingError === curr && timingError === 0}
           />
         </div>

--- a/gui/src/screens/Gantt/Gantt.jsx
+++ b/gui/src/screens/Gantt/Gantt.jsx
@@ -5,6 +5,7 @@ import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNav from 'sections/SecondaryNav/SecondaryNav'
 import SecondaryNavButtonList from 'components/SecondaryNavButtonList/SecondaryNavButtonList'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
+import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
 
 import PathogenesisGantt from './panel-list/PathogenesisGantt/PathogenesisGantt'
 import InteractiveGantt from './panel-list/InteractiveGantt/InteractiveGantt'
@@ -15,14 +16,15 @@ function Gantt({
   currentFilterList,
   data,
 }) {
-  const [ganttPanel, setGanttPanel] = useState('general')
+  const currentPanel = secondaryNavLocalStorage({ def: 'pathogenesis', k: i18nBase })
+  const [ganttPanel, setGanttPanel] = useState(currentPanel)
 
   if (!data || !data.length) { return null }
 
   const commonNavProps = {
     currentPanel: ganttPanel,
     i18nBase,
-    panelList: ['general','interactive'],
+    panelList: ['pathogenesis', 'interactive'],
     setCurrentPanel: setGanttPanel,
   }
 
@@ -44,7 +46,7 @@ function Gantt({
         </SecondaryNav>
       )}
     >
-      { ganttPanel === 'general' && (
+      { ganttPanel === 'pathogenesis' && (
         <PathogenesisGantt {...commonSubPageProps} />
       ) }
       { ganttPanel === 'interactive' && (

--- a/gui/src/screens/Gantt/Gantt.jsx
+++ b/gui/src/screens/Gantt/Gantt.jsx
@@ -5,7 +5,6 @@ import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNav from 'sections/SecondaryNav/SecondaryNav'
 import SecondaryNavButtonList from 'components/SecondaryNavButtonList/SecondaryNavButtonList'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
-import { GANTT_TOGGLE_LIST } from 'util/Constant/BaseConstantList'
 
 import PathogenesisGantt from './panel-list/PathogenesisGantt/PathogenesisGantt'
 import InteractiveGantt from './panel-list/InteractiveGantt/InteractiveGantt'
@@ -17,7 +16,6 @@ function Gantt({
   data,
 }) {
   const [ganttPanel, setGanttPanel] = useState('general')
-  const [ganttToggleList, setGanttTogglelList] = useState(GANTT_TOGGLE_LIST)
 
   if (!data || !data.length) { return null }
 
@@ -31,8 +29,6 @@ function Gantt({
   const commonSubPageProps = {
     currentFilterList,
     data,
-    setGanttTogglelList,
-    ganttToggleList,
   }
 
   return (

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 
 import AxisSelector from 'sections/AxisSelector/AxisSelector'
 import GanttChart from 'sections/GanttChart/GanttChart'
-import GanttToggleList from 'sections/GanttToggleList/GanttToggleList'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
 import { calcScale } from 'util/UtilGanttBarList/UtilGanttBarList'
@@ -13,8 +12,6 @@ import './InteractiveGantt.scss'
 function InteractiveGantt({
   currentFilterList,
   data,
-  setGanttTogglelList,
-  ganttToggleList,
 }) {
   const [currentResponse, setCurrentResponse] = useState('prime_symptom_1')
   const [currentGroupBy, setCurrentGroupBy] = useState('mild_symptom_1')
@@ -25,35 +22,30 @@ function InteractiveGantt({
 
   return (
     <SubPageWrapper>
-      <div className='interactive-gantt__wrapper column-layout space-children--column-with-border'>
-        <GanttToggleList
-          setGanttTogglelList={setGanttTogglelList}
-          ganttToggleList={ganttToggleList}
-        />
-        <div className='interactive-gantt row-layout space-children--wide'>
-          <div className='interactive-gantt__bar-selector'>
-            <AxisSelector
-              align='right'
-              axis='stats'
-              currentAxisSelection={currentResponse}
-              disabledSelection={currentGroupBy}
-              setCurrentAxisSelection={setCurrentResponse}
-            />
-          </div>
+      <div className='interactive-gantt__wrapper row-layout space-children--wide'>
+        <div className='interactive-gantt__bar-selector'>
+          <AxisSelector
+            align='right'
+            axis='stats'
+            currentAxisSelection={currentResponse}
+            disabledSelection={currentGroupBy}
+            setCurrentAxisSelection={setCurrentResponse}
+          />
+        </div>
+        <div className='interactive-gantt column-layout space-children--column-with-border'>
           <GanttChart
             currentFilterList={currentFilterList}
-            ganttToggleList={ganttToggleList}
             maxOfAll={maxOfAll}
             scale={scale}
             statDataList={statDataList}
           />
-          <AxisSelector
-            axis='groupBy'
-            currentAxisSelection={currentGroupBy}
-            disabledSelection={currentResponse}
-            setCurrentAxisSelection={setCurrentGroupBy}
-          />
         </div>
+        <AxisSelector
+          axis='groupBy'
+          currentAxisSelection={currentGroupBy}
+          disabledSelection={currentResponse}
+          setCurrentAxisSelection={setCurrentGroupBy}
+        />
       </div>
     </SubPageWrapper>
   );

--- a/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.scss
+++ b/gui/src/screens/Gantt/panel-list/InteractiveGantt/InteractiveGantt.scss
@@ -1,6 +1,12 @@
 @import '../../../../util/Constant/sass-variable-list.scss';
 
 .interactive-gantt {
+  width: 100%;
+
+  &.interactive-gantt {
+    @include self-space-row-remove-border();
+  }
+
   &__wrapper {
     width: 100%;
   }

--- a/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
+++ b/gui/src/screens/Gantt/panel-list/PathogenesisGantt/PathogenesisGantt.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import GanttChart from 'sections/GanttChart/GanttChart'
 import SubPageWrapper from 'components/SubPageWrapper/SubPageWrapper'
-import GanttToggleList from 'sections/GanttToggleList/GanttToggleList'
 import { CURRENT_FILTER_LIST } from 'util/Constant/FilterConstantList'
 import { calcPathogenesisGantt } from 'util/UtilGanttBarList/UtilPathogenesisGantt'
 
@@ -11,22 +10,15 @@ import './PathogenesisGantt.scss'
 function PathogenesisGantt({
   currentFilterList,
   data,
-  setGanttTogglelList,
-  ganttToggleList,
 }) {
   const statDataList = calcPathogenesisGantt({ currentFilterList, data })
 
   return (
     <SubPageWrapper>
-       <div className='pathogenesis-gantt__wrapper column-layout space-children--column-with-border'>
-        <GanttToggleList
-          setGanttTogglelList={setGanttTogglelList}
-          ganttToggleList={ganttToggleList}
-        />
+      <div className='pathogenesis-gantt__wrapper column-layout space-children--column-with-border'>
         <GanttChart
           currentFilterList={currentFilterList}
           statDataList={statDataList}
-          ganttToggleList={ganttToggleList}
         />
       </div>
     </SubPageWrapper>

--- a/gui/src/screens/HistogramMaker/HistogramMaker.jsx
+++ b/gui/src/screens/HistogramMaker/HistogramMaker.jsx
@@ -4,21 +4,24 @@ import { keys, map, pipe } from 'ramda'
 
 import AxisSelector from 'sections/AxisSelector/AxisSelector'
 import Histogram from 'sections/Histogram/Histogram'
+import Button from 'components/Button/Button'
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNav from 'sections/SecondaryNav/SecondaryNav'
-import Button from 'components/Button/Button'
-import { secondaryNavProps } from 'util/UtilNav/UtilNav'
-import { HISTOGRAM_BAR_LIST_MARGIN } from 'util/Constant/BaseConstantList'
 import { calcHistogramBarHue } from 'util/UtilHistogram/UtilHistogram'
+import { HISTOGRAM_BAR_LIST_MARGIN } from 'util/Constant/BaseConstantList'
+import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
+import { secondaryNavProps } from 'util/UtilNav/UtilNav'
+
 import { calcHistogramBarGroupList, dataFnList } from './HistogramMakerDataFunctions'
 import './HistogramMaker.scss'
 
 const i18nBase = 'HistogramMaker'
 
 function HistogramMaker({ data }) {
+  const barFn = secondaryNavLocalStorage({ def: 'count', k: i18nBase })
   const [currentPathogenesisStepList, setCurrentPathogenesisStepList] = useState(['mild_symptom_1', 'prime_symptom_3'])
   const [currentGroupBy, setCurrentGroupBy] = useState('fatal_symptom_1')
-  const [currentBarFn, setCurrentBarFn] = useState('count')
+  const [currentBarFn, setCurrentBarFn] = useState(barFn)
 
   if (!data || data.length === 0) {
     return null

--- a/gui/src/screens/Home/Home.jsx
+++ b/gui/src/screens/Home/Home.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNav from 'sections/SecondaryNav/SecondaryNav'
 import SecondaryNavButtonList from 'components/SecondaryNavButtonList/SecondaryNavButtonList'
+import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
 
 import Background from './panel-list/Background/Background'
 import Motivation from './panel-list/Motivation/Motivation'
@@ -16,10 +17,11 @@ import './Home.scss'
 const i18nBase = 'Home'
 
 function Home() {
-  const [currentPanel, setCurrentPanel] = useState('background')
+  const currentPanel = secondaryNavLocalStorage({ def: 'background', k: i18nBase })
+  const [currentHomePanel, setCurrentPanel] = useState(currentPanel)
 
   const commonNavProps = {
-    currentPanel,
+    currentPanel: currentHomePanel,
     i18nBase,
     panelList: ['background', 'motivation', 'techStack', 'testing', 'summary'],
     setCurrentPanel,
@@ -37,19 +39,19 @@ function Home() {
         </SecondaryNav>
       )}
     >
-      { currentPanel === 'background' && (
+      { currentHomePanel === 'background' && (
         <Background />
       ) }
-      { currentPanel === 'motivation' && (
+      { currentHomePanel === 'motivation' && (
         <Motivation />
       ) }
-      { currentPanel === 'techStack' && (
+      { currentHomePanel === 'techStack' && (
         <TechStack />
       ) }
-      { currentPanel === 'testing' && (
+      { currentHomePanel === 'testing' && (
         <Testing />
       ) }
-      { currentPanel === 'summary' && (
+      { currentHomePanel === 'summary' && (
         <Summary />
       ) }
     </PageDetailWrapper>

--- a/gui/src/screens/PrimeSymptomList/PrimeSymptomList.jsx
+++ b/gui/src/screens/PrimeSymptomList/PrimeSymptomList.jsx
@@ -3,7 +3,8 @@ import i18next from 'util/i18next/i18next'
 
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import PrimeSymptomHistogram from 'sections/PrimeSymptomHistogram/PrimeSymptomHistogram'
-import { PRIME_SYMPTOM_BLOCK_SIZE } from 'util/Constant/BaseConstantList'
+import { PRIME_SYMPTOM_BLOCK_SIZE, PRIME_SYMPTOM_HISTOGRAM_HEIGHT } from 'util/Constant/BaseConstantList'
+import { primeSymptomLocalStorage } from 'util/UtilLocalStorage/UtilPrimeSymptom'
 
 const i18nBase = 'PrimeSymptomList'
 
@@ -16,7 +17,9 @@ function PrimeSymptomList({ data }) {
     >
       <PrimeSymptomHistogram
         blockSize={PRIME_SYMPTOM_BLOCK_SIZE}
-        histogramHeight={56}
+        histogramHeight={PRIME_SYMPTOM_HISTOGRAM_HEIGHT}
+        localStorageKey='primeSymptom'
+        localStorageFn={primeSymptomLocalStorage}
         primeSymptomData={data}
       />
     </PageDetailWrapper>

--- a/gui/src/screens/PrimeSymptomList/PrimeSymptomList.test.js
+++ b/gui/src/screens/PrimeSymptomList/PrimeSymptomList.test.js
@@ -3,10 +3,14 @@ import userEvent from '@testing-library/user-event'
 import { getByLabelText, render, screen, waitFor } from '@testing-library/react'
 
 import APIPrimeSymptomListData from 'example-data/APIPrimeSymptomList.example-data'
+import { setJSONLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import PrimeSymptomList from './PrimeSymptomList'
 
 test('PrimeSymptomList - ', async () => {
+  // make sure the stored values match the test
+  setJSONLocalStorage({ k: 'primeSymptom', v: { count: 20, factor: true }})
+
   render(
     <PrimeSymptomList
       data={APIPrimeSymptomListData}

--- a/gui/src/screens/TimeLine/TimeLine.jsx
+++ b/gui/src/screens/TimeLine/TimeLine.jsx
@@ -8,6 +8,7 @@ import MonthText from 'components/MonthText/MonthText'
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNavSumAndFilterList from 'sections/SecondaryNavSumAndFilterList/SecondaryNavSumAndFilterList'
 import TimeLineDataPropType from 'prop-types/TimeLineData.prop-type'
+import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
 import { DATA_POINT_SUM_LIST, TIME_LINE_FILTER_LIST } from 'util/Constant/BaseConstantList'
 import {
   calcColorVal,
@@ -30,7 +31,8 @@ const monthTotal = calcShownMonthTotal()
 const thisMonthKey = calcThisMonthKey()
 
 function TimeLine({ data }) {
-  const [dataPointSumPerMonth, setDataPointSumPerMonth] = useState('overall_patient_rating')
+  const currentSumPer = secondaryNavLocalStorage({ def: 'overall_patient_rating', k: i18nBase })
+  const [dataPointSumPerMonth, setDataPointSumPerMonth] = useState(currentSumPer)
   const [filterBy, setFilterBy] = useState([null, null])
 
   if (!data?.length) {

--- a/gui/src/screens/TimeLine/TimeLine.jsx
+++ b/gui/src/screens/TimeLine/TimeLine.jsx
@@ -8,7 +8,9 @@ import MonthText from 'components/MonthText/MonthText'
 import PageDetailWrapper from 'components/PageDetailWrapper/PageDetailWrapper'
 import SecondaryNavSumAndFilterList from 'sections/SecondaryNavSumAndFilterList/SecondaryNavSumAndFilterList'
 import TimeLineDataPropType from 'prop-types/TimeLineData.prop-type'
+import { setJSONLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 import { secondaryNavLocalStorage } from 'util/UtilLocalStorage/UtilSecondaryNav'
+import { timeLineFilterByLocalStorage } from 'util/UtilLocalStorage/UtilTimeLineFilteredBy'
 import { DATA_POINT_SUM_LIST, TIME_LINE_FILTER_LIST } from 'util/Constant/BaseConstantList'
 import {
   calcColorVal,
@@ -32,8 +34,9 @@ const thisMonthKey = calcThisMonthKey()
 
 function TimeLine({ data }) {
   const currentSumPer = secondaryNavLocalStorage({ def: 'overall_patient_rating', k: i18nBase })
+  const persistedFilterBy = timeLineFilterByLocalStorage({ k: 'timeLineFilteredBy' })
   const [dataPointSumPerMonth, setDataPointSumPerMonth] = useState(currentSumPer)
-  const [filterBy, setFilterBy] = useState([null, null])
+  const [filterBy, setFilterBy] = useState(persistedFilterBy)
 
   if (!data?.length) {
     return null
@@ -71,7 +74,10 @@ function TimeLine({ data }) {
                   <Button
                     isSelected={isSelected}
                     label={label}
-                    onClick={() => setFilterBy(filter)}
+                    onClick={() => {
+                      setFilterBy(filter)
+                      setJSONLocalStorage({ k: 'timeLineFilteredBy', v: filter})
+                    }}
                     size='medium'
                   />
                 </li>

--- a/gui/src/sections/GanttBarList/GanttBarList.jsx
+++ b/gui/src/sections/GanttBarList/GanttBarList.jsx
@@ -44,6 +44,7 @@ function GanttBarList({
           scale,
           ganttToggleList,
         }
+
         return (
           <GanttBarWrapper {...dataBarWrapperProps}>
             <GanttBar {...dataBarProps} />

--- a/gui/src/sections/GanttChart/GanttChart.jsx
+++ b/gui/src/sections/GanttChart/GanttChart.jsx
@@ -4,91 +4,100 @@ import React, { useState } from 'react'
 import Button from 'components/Button/Button'
 import GanttBarList from 'sections/GanttBarList/GanttBarList'
 import GanttScale from 'sections/GanttScale/GanttScale'
-import { GANTT_SCALE_DEFAULT } from 'util/Constant/BaseConstantList'
+import GanttToggleList from 'sections/GanttToggleList/GanttToggleList'
 import { calcGanttListHeight } from 'util/UtilGanttBarList/UtilGanttBarList'
+import { GANTT_SCALE_DEFAULT } from 'util/Constant/BaseConstantList'
+import { ganttToggleListLocalStorage } from 'util/UtilLocalStorage/UtilGanttToggleList'
 
 import './GanttChart.scss'
 
 function GanttChart({
   currentFilterList,
-  ganttToggleList,
   maxOfAll,
   scale,
   statDataList,
 }) {
   const { totalSteps } = scale
+  const persistedGanttToggleList = ganttToggleListLocalStorage()
+  const [ganttToggleList, setGanttToggleList] = useState(persistedGanttToggleList)
   const [stepPair, setStepPair] = useState({ first: 0, last: totalSteps, lastSet: 'first' })
   const scaleRange = range(0, totalSteps + 1)
 
   const ganttHeight = calcGanttListHeight({ statDataList })
 
   return (
-    <figure
-      className='gantt-chart column-layout space-children--wide-column'
-    >
-      <div className='gantt-chart__zoom-button-list row-layout'>
-        <ol className='row-layout space-children'>
-          {scaleRange.map(i => {
-            return (
-              <li key={`zoom-${i}`}>
-                <Button
-                  extraClass={`gantt-chart__zoom-button${
-                    (
-                      i <= stepPair.last
-                      &&
-                      i >= stepPair.first
-                    )
-                      ? ' is-selected'
-                      : ''
-                  }`}
-                  isDisabled={
-                    (
-                      i < stepPair.first
-                      &&
-                      stepPair.lastSet === 'first'
-                    )
-                    ||
-                    (
-                      i > stepPair.last
-                      &&
-                      stepPair.lastSet === 'last'
-                    )
-                  }
-                  label={(i * scale.stepDivision)}
-                  onClick={
-                    () => {
-                      const pair = stepPair.lastSet === 'first'
-                        ? {
-                          first: stepPair.first,
-                          last: i,
-                          lastSet: 'last',
-                        } : {
-                          first: i,
-                          last: stepPair.last,
-                          lastSet: 'first',
-                        }
-                      setStepPair(pair)
-                    }
-                  }
-                />
-              </li>
-            )
-          })}
-        </ol>
-      </div>
-      <GanttScale
-        ariaLabel='clinical response timings'
-        ganttHeight={ganttHeight}
-        scale={{ ...scale, firstStep: stepPair.first, lastStep: stepPair.last }}
-      />
-      <GanttBarList
-        currentFilterList={currentFilterList}
-        maxOfAll={maxOfAll}
-        scale={{ ...scale, firstStep: stepPair.first, lastStep: stepPair.last }}
+    <>
+      <GanttToggleList
         ganttToggleList={ganttToggleList}
-        statDataList={statDataList}
+        setGanttToggleList={setGanttToggleList}
       />
-    </figure>
+      <figure
+        className='gantt-chart column-layout space-children--wide-column'
+      >
+        <div className='gantt-chart__zoom-button-list row-layout'>
+          <ol className='row-layout space-children'>
+            {scaleRange.map(i => {
+              return (
+                <li key={`zoom-${i}`}>
+                  <Button
+                    extraClass={`gantt-chart__zoom-button${
+                      (
+                        i <= stepPair.last
+                        &&
+                        i >= stepPair.first
+                      )
+                        ? ' is-selected'
+                        : ''
+                    }`}
+                    isDisabled={
+                      (
+                        i < stepPair.first
+                        &&
+                        stepPair.lastSet === 'first'
+                      )
+                      ||
+                      (
+                        i > stepPair.last
+                        &&
+                        stepPair.lastSet === 'last'
+                      )
+                    }
+                    label={(i * scale.stepDivision)}
+                    onClick={
+                      () => {
+                        const pair = stepPair.lastSet === 'first'
+                          ? {
+                            first: stepPair.first,
+                            last: i,
+                            lastSet: 'last',
+                          } : {
+                            first: i,
+                            last: stepPair.last,
+                            lastSet: 'first',
+                          }
+                        setStepPair(pair)
+                      }
+                    }
+                  />
+                </li>
+              )
+            })}
+          </ol>
+        </div>
+        <GanttScale
+          ariaLabel='clinical response timings'
+          ganttHeight={ganttHeight}
+          scale={{ ...scale, firstStep: stepPair.first, lastStep: stepPair.last }}
+        />
+        <GanttBarList
+          currentFilterList={currentFilterList}
+          ganttToggleList={ganttToggleList}
+          maxOfAll={maxOfAll}
+          scale={{ ...scale, firstStep: stepPair.first, lastStep: stepPair.last }}
+          statDataList={statDataList}
+        />
+      </figure>
+    </>
   )
 }
 

--- a/gui/src/sections/GanttToggleList/GanttToggleList.jsx
+++ b/gui/src/sections/GanttToggleList/GanttToggleList.jsx
@@ -6,13 +6,14 @@ import { keys } from 'ramda'
 import Button from 'components/Button/Button'
 import GanttToggleListPropType from 'prop-types/GanttToggleList.prop-type'
 import { GANTT_TOGGLE_LIST } from 'util/Constant/BaseConstantList'
+import { setJSONLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import './GanttToggleList.scss'
 
 const i18nBase = 'GanttToggleList'
 
 function GanttToggleList({
-  setGanttTogglelList,
+  setGanttToggleList,
   ganttToggleList,
 }) {
   return (
@@ -23,7 +24,11 @@ function GanttToggleList({
           isSelected,
           extraClass: `${isSelected ? ' is-selected--secondary' : ''}`,
           label: i18next.t(`${i18nBase}.${statDetail}`),
-          onClick: () => setGanttTogglelList({ ...ganttToggleList, [statDetail]: !isSelected }),
+          onClick: () => {
+            const newToggleList = { ...ganttToggleList, [statDetail]: !isSelected }
+            setGanttToggleList(newToggleList)
+            setJSONLocalStorage({ k: 'ganttToggleList', v: newToggleList })
+          },
           size: 'small',
         }
         return (
@@ -44,7 +49,7 @@ GanttToggleList.defaultProps = {
 }
 
 GanttToggleList.propTypes = {
-  setGanttTogglelList: PropTypes.func,
+  setGanttToggleList: PropTypes.func,
   ganttToggleList: GanttToggleListPropType,
 }
 

--- a/gui/src/sections/PrimeSymptomHistogram/PrimeSymptomHistogram.jsx
+++ b/gui/src/sections/PrimeSymptomHistogram/PrimeSymptomHistogram.jsx
@@ -22,6 +22,7 @@ import {
   primeSymptomHistogramBarGrouper,
   primeSymptomTimingError,
 } from 'util/UtilPrimeSymptomHistogram/UtilPrimeSymptomHistogram'
+import { setJSONLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 import './PrimeSymptomHistogram.scss'
 
@@ -31,11 +32,14 @@ function PrimeSymptomHistogram({
   badTimingError,
   blockSize,
   histogramHeight,
+  localStorageFn,
+  localStorageKey,
   primeSymptomData,
   timingError,
 }) {
-  const [currentDisplayedDataPoints, setCurrentDisplayedDataPoints] = useState(primeSymptomData?.length || PRIME_SYMPTOM_MINIMUM_COUNT)
-  const [currentFactorOn, setCurrentFactorOn] = useState(true)
+  const { count, factor: localStorageFactor } = localStorageFn({ k: localStorageKey })
+  const [currentDisplayedDataPoints, setCurrentDisplayedDataPoints] = useState(count || primeSymptomData?.length || PRIME_SYMPTOM_MINIMUM_COUNT)
+  const [currentFactorOn, setCurrentFactorOn] = useState(localStorageFactor)
 
   const totalAvailableDataPoints = primeSymptomData?.length
 
@@ -52,6 +56,8 @@ function PrimeSymptomHistogram({
   if (!primeSymptomData?.length) {
     return null
   }
+
+  setJSONLocalStorage({ k: localStorageKey, v: { count: currentDisplayedDataPoints, factor: currentFactorOn } })
 
   const histogramData = ramda.pipe(
     ramda.take(currentDisplayedDataPoints),
@@ -141,6 +147,8 @@ PrimeSymptomHistogram.defaultProps = {
 PrimeSymptomHistogram.propTypes = {
   badTimingError: PropTypes.number,
   blockSize: PropTypes.number,
+  localStorageFn: PropTypes.func,
+  localStorageKey: PropTypes.oneOf(['primeSymptom', 'primeSymptomAntiBias']),
   primeSymptomData: PropTypes.array,
   timingError: PropTypes.number,
 }

--- a/gui/src/sections/PrimeSymptomHistogram/PrimeSymptomHistogram.test.js
+++ b/gui/src/sections/PrimeSymptomHistogram/PrimeSymptomHistogram.test.js
@@ -6,8 +6,12 @@ import APIPrimeSymptomListData from 'example-data/APIPrimeSymptomList.example-da
 
 import PrimeSymptomHistogram from './PrimeSymptomHistogram'
 
+// test works with a full set of data so local storage stub needs to match this
+const TEST_COUNT = 20
+
 
 const basePrimeSymptomHistogramProps = {
+  localStorageFn: () => ({ count: TEST_COUNT, factor: true }),
   primeSymptomData: APIPrimeSymptomListData,
 }
 
@@ -27,7 +31,7 @@ test('PrimeSymptomHistogram - user key interaction', async () => {
    */
   expect(screen.getByText('Increase data as added')).toBeTruthy()
   expect(screen.getByText('Total:')).toBeTruthy()
-  expect(screen.getByText('20')).toBeTruthy()
+  expect(screen.getByText(TEST_COUNT)).toBeTruthy()
   expect(screen.getByText('Severe: 11')).toBeTruthy()
   expect(screen.getByText('Non Severe: 9')).toBeTruthy()
 

--- a/gui/src/sections/SecondaryNav/SecondaryNav.scss
+++ b/gui/src/sections/SecondaryNav/SecondaryNav.scss
@@ -19,7 +19,7 @@
 
   &.research {
     & > * {
-      @media (max-width: 984px) {
+      @media (max-width: 1240px) {
         margin-top: var(--spacing--narrow);
       }
     }

--- a/gui/src/util/Constant/BaseConstantList.js
+++ b/gui/src/util/Constant/BaseConstantList.js
@@ -127,6 +127,7 @@ export const PRIME_SYMPTOM_BLOCK_SIZE = (
   *
   2
 )
+export const PRIME_SYMPTOM_HISTOGRAM_HEIGHT = 56
 
 
 /***********************************/

--- a/gui/src/util/UtilLocalStorage/UtilDataAdjuster.js
+++ b/gui/src/util/UtilLocalStorage/UtilDataAdjuster.js
@@ -1,0 +1,12 @@
+import { getLocalStorage } from './UtilLocalStorage'
+
+export function dataAdjusterLocalStorage({ k }) {
+  const result = getLocalStorage({ k })
+  return (
+    result
+    &&
+    result !== 'undefined'
+  )
+    ? Number(result)
+    : Number('0')
+}

--- a/gui/src/util/UtilLocalStorage/UtilDataAdjuster.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilDataAdjuster.test.js
@@ -1,0 +1,17 @@
+import {
+  setLocalStorage,
+} from './UtilLocalStorage'
+
+import {
+  dataAdjusterLocalStorage,
+} from './UtilDataAdjuster'
+
+test('we can set and get a value from local storage', () => {
+  setLocalStorage({ k: 'testKey', v: 5 })
+  expect(dataAdjusterLocalStorage({ k: 'testKey' })).toEqual(5)
+})
+
+test('and it uses the default', () => {
+  setLocalStorage({ k: 'testKey' })
+  expect(dataAdjusterLocalStorage({ k: 'testKey' })).toEqual(0)
+})

--- a/gui/src/util/UtilLocalStorage/UtilGanttToggleList.js
+++ b/gui/src/util/UtilLocalStorage/UtilGanttToggleList.js
@@ -1,0 +1,6 @@
+import { getJSONLocalStorage } from './UtilLocalStorage'
+import { GANTT_TOGGLE_LIST } from 'util/Constant/BaseConstantList'
+
+export function ganttToggleListLocalStorage() {
+  return getJSONLocalStorage({ k: 'ganttToggleList' }) || GANTT_TOGGLE_LIST
+}

--- a/gui/src/util/UtilLocalStorage/UtilGanttToggleList.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilGanttToggleList.test.js
@@ -1,0 +1,12 @@
+import {
+  setJSONLocalStorage,
+} from './UtilLocalStorage'
+
+import {
+  ganttToggleListLocalStorage,
+} from './UtilGanttToggleList'
+
+test('we can set and get a value from local storage', () => {
+  setJSONLocalStorage({ k: 'ganttToggleList', v: { x: 'y', a: 'b' } })
+  expect(ganttToggleListLocalStorage()).toEqual({ x: 'y', a: 'b' })
+})

--- a/gui/src/util/UtilLocalStorage/UtilLocalStorage.js
+++ b/gui/src/util/UtilLocalStorage/UtilLocalStorage.js
@@ -1,0 +1,7 @@
+export function setLocalStorage({ k, v }) {
+  localStorage.setItem(k, v)
+}
+
+export function getLocalStorage({ k }) {
+  return localStorage.getItem(k)
+}

--- a/gui/src/util/UtilLocalStorage/UtilLocalStorage.js
+++ b/gui/src/util/UtilLocalStorage/UtilLocalStorage.js
@@ -5,3 +5,11 @@ export function setLocalStorage({ k, v }) {
 export function getLocalStorage({ k }) {
   return localStorage.getItem(k)
 }
+
+export function setJSONLocalStorage({ k, v }) {
+  localStorage.setItem(k, JSON.stringify(v))
+}
+
+export function getJSONLocalStorage({ k }) {
+  return JSON.parse(localStorage.getItem(k))
+}

--- a/gui/src/util/UtilLocalStorage/UtilLocalStorage.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilLocalStorage.test.js
@@ -1,9 +1,21 @@
 import {
   setLocalStorage,
+  setJSONLocalStorage,
   getLocalStorage,
+  getJSONLocalStorage,
 } from './UtilLocalStorage'
 
 test('we can set and get a value from local storage', () => {
   setLocalStorage({ k: 'a', v: 'b' })
   expect(getLocalStorage({ k: 'a' })).toEqual('b')
+})
+
+test('we can set and get a value from local storage when it is an object', () => {
+  setJSONLocalStorage({ k: 'a', v: { x: 'y' } })
+  expect(getJSONLocalStorage({ k: 'a' })).toEqual({ x: 'y' })
+})
+
+test('we can set and get a value from local storage when it is an array', () => {
+  setJSONLocalStorage({ k: 'a', v: [1, 2, 3] })
+  expect(getJSONLocalStorage({ k: 'a' })).toEqual([1, 2, 3])
 })

--- a/gui/src/util/UtilLocalStorage/UtilLocalStorage.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilLocalStorage.test.js
@@ -1,0 +1,9 @@
+import {
+  setLocalStorage,
+  getLocalStorage,
+} from './UtilLocalStorage'
+
+test('we can set and get a value from local storage', () => {
+  setLocalStorage({ k: 'a', v: 'b' })
+  expect(getLocalStorage({ k: 'a' })).toEqual('b')
+})

--- a/gui/src/util/UtilLocalStorage/UtilPrimeSymptom.js
+++ b/gui/src/util/UtilLocalStorage/UtilPrimeSymptom.js
@@ -1,0 +1,10 @@
+import { PRIME_SYMPTOM_MINIMUM_COUNT } from 'util/Constant/BaseConstantList'
+import { getJSONLocalStorage } from './UtilLocalStorage'
+
+export function primeSymptomLocalStorage({ k }) {
+  return getJSONLocalStorage({ k: 'primeSymptom' }) || { count: PRIME_SYMPTOM_MINIMUM_COUNT, factor: true }
+}
+
+export function primeSymptomAntiBiasLocalStorage({ k }) {
+  return getJSONLocalStorage({ k: 'primeSymptomAntiBias'}) || { count: PRIME_SYMPTOM_MINIMUM_COUNT, factor: true }
+}

--- a/gui/src/util/UtilLocalStorage/UtilPrimeSymptom.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilPrimeSymptom.test.js
@@ -1,0 +1,28 @@
+import {
+  setJSONLocalStorage,
+} from './UtilLocalStorage'
+
+import {
+  primeSymptomAntiBiasLocalStorage,
+  primeSymptomLocalStorage,
+} from './UtilPrimeSymptom'
+
+test('we can set and get a primeSymptomsvalue from local storage', () => {
+  setJSONLocalStorage({ k: 'primeSymptom', v: { count: 15, factor: false } })
+  expect(primeSymptomLocalStorage({ k: 'primeSymptom' })).toEqual({ count: 15, factor: false })
+})
+
+test('and this uses the default too', () => {
+  setJSONLocalStorage({ k: 'primeSymptom', v: null })
+  expect(primeSymptomLocalStorage({ k: 'primeSymptom' })).toEqual({ count: 5, factor: true })
+})
+
+test('we can set and get a primeSymptomAntiBias value from local storage', () => {
+  setJSONLocalStorage({ k: 'primeSymptomAntiBias', v: { count: 23, factor: false } })
+  expect(primeSymptomAntiBiasLocalStorage({ k: 'primeSymptomAntiBias' })).toEqual({ count: 23, factor: false })
+})
+
+test('and this uses the default too', () => {
+  setJSONLocalStorage({ k: 'primeSymptomAntiBias', v: null })
+  expect(primeSymptomAntiBiasLocalStorage({ k: 'primeSymptomAntiBias' })).toEqual({ count: 5, factor: true })
+})

--- a/gui/src/util/UtilLocalStorage/UtilSecondaryNav.js
+++ b/gui/src/util/UtilLocalStorage/UtilSecondaryNav.js
@@ -1,0 +1,5 @@
+import { getLocalStorage } from './UtilLocalStorage'
+
+export function secondaryNavLocalStorage({ def, k }) {
+  return getLocalStorage({ k }) || def
+}

--- a/gui/src/util/UtilLocalStorage/UtilSecondaryNav.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilSecondaryNav.test.js
@@ -1,0 +1,17 @@
+import {
+  setLocalStorage,
+} from './UtilLocalStorage'
+
+import {
+  secondaryNavLocalStorage,
+} from './UtilSecondaryNav'
+
+test('we can set and get a value from local storage', () => {
+  setLocalStorage({ k: 'Test', v: 'this-panel' })
+  expect(secondaryNavLocalStorage({ k: 'Test' })).toEqual('this-panel')
+})
+
+test('and this uses the default too', () => {
+  setLocalStorage({ k: 'This', v: 'this-panel' })
+  expect(secondaryNavLocalStorage({ def: 'default-test', k: 'That '})).toEqual('default-test')
+})

--- a/gui/src/util/UtilLocalStorage/UtilTimeLineFilteredBy.js
+++ b/gui/src/util/UtilLocalStorage/UtilTimeLineFilteredBy.js
@@ -1,0 +1,5 @@
+import { getJSONLocalStorage } from './UtilLocalStorage'
+
+export function timeLineFilterByLocalStorage({ k }) {
+  return getJSONLocalStorage({ k }) || [null, null]
+}

--- a/gui/src/util/UtilLocalStorage/UtilTimeLineFilteredBy.test.js
+++ b/gui/src/util/UtilLocalStorage/UtilTimeLineFilteredBy.test.js
@@ -1,0 +1,17 @@
+import {
+  setJSONLocalStorage,
+} from './UtilLocalStorage'
+
+import {
+  timeLineFilterByLocalStorage,
+} from './UtilTimeLineFilteredBy'
+
+test('we can set and get a value from local storage', () => {
+  setJSONLocalStorage({ k: 'timeLineFilteredBy', v: [1, 2] })
+  expect(timeLineFilterByLocalStorage({ k: 'timeLineFilteredBy' })).toEqual([1, 2])
+})
+
+test('and this uses the default too', () => {
+  setJSONLocalStorage({ k: 'This', v: 'this-panel' })
+  expect(timeLineFilterByLocalStorage({ k: 'timeLineFilteredBy '})).toEqual([null, null])
+})

--- a/gui/src/util/UtilNav/UtilNav.js
+++ b/gui/src/util/UtilNav/UtilNav.js
@@ -2,6 +2,7 @@ import { type } from 'ramda'
 import i18next from 'util/i18next/i18next'
 
 import { throwError } from 'util/Util/Util'
+import { setLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
 
 
 // These arev used all over to create sub-pages so get built in utils
@@ -14,7 +15,10 @@ export function secondaryNavProps({ currentPanel, i18nBase, k, setCurrentPanel }
   return {
     isSelected: currentPanel === k,
     label: i18next.t(`${i18nBase}.${k}PanelLabel`),
-    onClick: () => setCurrentPanel(k),
+    onClick: () => {
+      setLocalStorage({ k: i18nBase, v: k })
+      setCurrentPanel(k)
+    },
     size: 'medium',
   }
 }

--- a/gui/src/util/UtilNav/UtilNav.test.js
+++ b/gui/src/util/UtilNav/UtilNav.test.js
@@ -5,7 +5,7 @@ import { secondaryNavProps } from './UtilNav'
  * secondaryNavProps()
  */
 test('secondaryNavProps()', () => {
-  const setCurrentPanel = () => 'test-b'
+  const setCurrentPanel = jest.fn()
 
   const args = {
     currentPanel: 'test-b',
@@ -25,7 +25,8 @@ test('secondaryNavProps()', () => {
   expect(expected.isSelected).toEqual(result.isSelected)
   expect(expected.label).toEqual(result.label)
   expect(expected.size).toEqual(result.size)
-  expect(result.onClick()).toEqual('test-b')
+  result.onClick()
+  expect(setCurrentPanel).toHaveBeenCalledWith('test-a')
 })
 
 

--- a/gui/src/util/i18next/de.json
+++ b/gui/src/util/i18next/de.json
@@ -348,7 +348,7 @@
   "Gantt": {
     "subHeading": "Grundlegende Zeitstatistiken, über gemeinsame Antworten und mit interaktiven Querverweisen",
     "interactivePanelLabel": "Interaktive Gantt",
-    "generalPanelLabel": "Pathogenesis Gantt",
+    "pathogenesisPanelLabel": "Pathogenesis Gantt",
     "ariaLabel": "{{label}}; Bereich {{min}} bis {{max}} mit mean {{mean}} Standardabweichung {{minStd}} bis {{maxStd}}",
     "secondaryNav": "Siehe Antwortzeitstatistiken oder interaktiv, wo Sie auswählen können, was gruppiert werden soll und wo Sie Statistiken über"
   },

--- a/gui/src/util/i18next/en.json
+++ b/gui/src/util/i18next/en.json
@@ -357,7 +357,7 @@
   "Gantt": {
     "subHeading": "Basic timing statistics, across common responses and with interactive cross referencing",
     "interactivePanelLabel": "Interactive Gantt",
-    "generalPanelLabel": "Pathogenesis Gantt",
+    "pathogenesisPanelLabel": "Pathogenesis Gantt",
     "ariaLabel": "{{label}}; range {{range}} with mean {{mean}} Standard deviation {{stddev}}",
     "secondaryNav": "See response time statistics or interactive where you can choose what to group and see time statistics about"
   },

--- a/gui/src/util/i18next/i18next.js
+++ b/gui/src/util/i18next/i18next.js
@@ -1,6 +1,8 @@
 import i18next from 'i18next'
 import { initReactI18next } from "react-i18next";
 
+import { getLocalStorage } from 'util/UtilLocalStorage/UtilLocalStorage'
+
 import de from './de'
 import en from './en'
 // import mask from './mask'
@@ -8,7 +10,7 @@ import en from './en'
 i18next
   .use(initReactI18next)
   .init({
-    lng: localStorage.getItem('currentLanguage') || 'en', // if you're using a language detector, do not define the lng option
+    lng: getLocalStorage({ k: 'currentLanguage' }) || 'en', // if you're using a language detector, do not define the lng option
     debug: false,
     resources: {
       de: { translation: de },

--- a/npal.md
+++ b/npal.md
@@ -188,6 +188,7 @@ Use different words for other types of 'get':
 * `set` for stores
 * `Mapper` always suffixes a map fn
 * `Grouper` for an fn that groups stuff like, but not limited to Ramda's `groupBy`
+* `persisted` for anything from local storage
 
 **Don't try to compose sentences out of test strings** use a hyphen at the end and describe blocks to break up logically.
 


### PR DESCRIPTION
If using multiple graphs to illustrate a point it helps for those graphs to maintain their appearance between sreen switches and even between site visits.

* a util was created - possibly not needed, we'll see, it brings together a single function in a single place, for example, if we wanted to encrypt everything on a user's computer so it was only readable when they were logged in and had some salt variable available
* apply to GanttToggleList
* apply to secondary nav
* apply to TimeLine filters
* apply to prime symptom graphs
* apply to data adjuster buttons

Note: not yet applied to [Axis selectors](https://github.com/toni-sharpe/brainstem-research/issues/155) or [main filters](https://github.com/toni-sharpe/brainstem-research/issues/155), those are ticketed up separately